### PR TITLE
Msg counter

### DIFF
--- a/app/poker_engine/broadcaster.rb
+++ b/app/poker_engine/broadcaster.rb
@@ -1,11 +1,11 @@
 class Broadcaster
+  attr_accessor :ask_counter  # write for deserialize
 
   def initialize(server, room, ask_counter=0)
     @server = server
     @room = room
     @ask_counter = ask_counter
   end
-
 
   def notification(data)
     @server.broadcast "room:#{@room.id}", notification_message(data)

--- a/app/poker_engine/broadcaster.rb
+++ b/app/poker_engine/broadcaster.rb
@@ -1,8 +1,9 @@
 class Broadcaster
 
-  def initialize(server, room)
+  def initialize(server, room, ask_counter=0)
     @server = server
     @room = room
+    @ask_counter = ask_counter
   end
 
 
@@ -13,6 +14,7 @@ class Broadcaster
   def ask(uuid, data)
     player = @room.players.find_by_uuid(uuid)
     @server.broadcast "room:#{@room.id}:#{player.id}", ask_message(data)
+    @ask_counter += 1
   end
 
 
@@ -28,6 +30,7 @@ class Broadcaster
       {}.merge!(phase: "play_poker")\
         .merge!(type: "ask")\
         .merge!(message: data)
+        .merge!(counter: @ask_counter)
     end
 
 end

--- a/app/poker_engine/dealer.rb
+++ b/app/poker_engine/dealer.rb
@@ -67,19 +67,6 @@ class Dealer
 
   private
 
-   def build_state_dump(table, config)
-     {
-       "config" => config,
-       "table" => table,
-       "round_count" => @round_count,
-       "round_manager" => {
-         "street" => @round_manager.street,
-         "agree_num" => @round_manager.agree_num,
-         "next_player" => @round_manager.next_player
-       }
-     }
-   end
-
     def start_round
       @round_manager.start_new_round(@table)
     end

--- a/app/poker_engine/dealer_serializer.rb
+++ b/app/poker_engine/dealer_serializer.rb
@@ -10,23 +10,22 @@ module DealerSerializer
   class_methods do
     def deserialize(components_holder, json)
      dump = JSON.parse(json)
+
+     config = Marshal.load(dump["config"])
+     table = Marshal.load(dump["table"])
+
      round_manager = components_holder[:round_manager]
-     state = dump["round_manager"]
-     street = state["street"]
-     agree_num = state["agree_num"]
-     next_player = state["next_player"]
-     round_manager.set_state(street, agree_num, next_player)
+     round_manager = round_manager_from_dump(round_manager, dump)
 
      broadcaster = components_holder[:broadcaster]
      broadcaster.ask_counter = dump["broadcaster"]["ask_counter"]
-     config = Marshal.load(dump["config"])
-     table = Marshal.load(dump["table"])
 
       components_holder
         .merge!( { config: config } )
         .merge!( { table: table } )
         .merge!( { round_manager: round_manager } )
         .merge!( { broadcaster: broadcaster } )
+
       Dealer.new(components_holder, round_count=dump["round_count"])
     end
   end

--- a/app/poker_engine/dealer_serializer.rb
+++ b/app/poker_engine/dealer_serializer.rb
@@ -16,6 +16,9 @@ module DealerSerializer
      agree_num = state["agree_num"]
      next_player = state["next_player"]
      round_manager.set_state(street, agree_num, next_player)
+
+     broadcaster = components_holder[:broadcaster]
+     broadcaster.ask_counter = dump["broadcaster"]["ask_counter"]
      config = Marshal.load(dump["config"])
      table = Marshal.load(dump["table"])
 
@@ -23,6 +26,7 @@ module DealerSerializer
         .merge!( { config: config } )
         .merge!( { table: table } )
         .merge!( { round_manager: round_manager } )
+        .merge!( { broadcaster: broadcaster } )
       Dealer.new(components_holder, round_count=dump["round_count"])
     end
   end
@@ -38,6 +42,9 @@ module DealerSerializer
          "street" => @round_manager.street,
          "agree_num" => @round_manager.agree_num,
          "next_player" => @round_manager.next_player
+       },
+       "broadcaster" => {
+         "ask_counter" => @broadcaster.ask_counter
        }
      }
    end

--- a/app/poker_engine/dealer_serializer.rb
+++ b/app/poker_engine/dealer_serializer.rb
@@ -48,14 +48,16 @@ module DealerSerializer
      }
    end
 
-   def round_manager_from_dump(round_manager, dump)
-     state = dump["round_manager"]
-     round_manager.tap { |round_manager|
-       street = state["street"]
-       agree_num = state["agree_num"]
-       next_player = state["next_player"]
-       round_manager.set_state(street, agree_num, next_player)
-       }
+   class_methods do
+     def round_manager_from_dump(round_manager, dump)
+       state = dump["round_manager"]
+       round_manager.tap { |round_manager|
+         street = state["street"]
+         agree_num = state["agree_num"]
+         next_player = state["next_player"]
+         round_manager.set_state(street, agree_num, next_player)
+         }
+     end
    end
 
 end

--- a/spec/features/dealer_spec.rb
+++ b/spec/features/dealer_spec.rb
@@ -147,6 +147,7 @@ RSpec.describe Dealer do
   end
 
   describe "serialization" do
+    let(:broadcaster) { Broadcaster.new("server", "room", 5) }
     let(:config) { Config.new(initial_stack=100, max_round=1) }
     let(:room) do
       double("room").tap { |room|
@@ -180,6 +181,8 @@ RSpec.describe Dealer do
         expect(copy["round_manager"]["street"]).to eq orig["round_manager"]["street"]
         expect(copy["round_manager"]["agree_num"]).to eq orig["round_manager"]["agree_num"]
         expect(copy["round_manager"]["next_player"]).to eq orig["round_manager"]["next_player"]
+
+        expect(copy["broadcaster"]["ask_counter"]).to eq orig["broadcaster"]["ask_counter"]
       end
     end
 

--- a/spec/poker_engine/broadcaster_spec.rb
+++ b/spec/poker_engine/broadcaster_spec.rb
@@ -26,14 +26,22 @@ RSpec.describe Broadcaster do
   end
 
   describe "ask" do
+    let(:channel) { "room:#{room.id}:#{player.id}" }
+    let(:params) {
+      { phase: "play_poker", type: "ask", counter: 0, message: "hoge" }
+    }
 
     it "should broadcast expected message" do
-      channel = "room:#{room.id}:#{player.id}"
-      params = { phase: "play_poker", type: "ask", message: "hoge" }
-
       expect(server).to receive(:broadcast).with(channel, params)
 
       broadcaster.ask(player.uuid, "hoge")
+    end
+
+    it "should increment ask count" do
+      second_params = params.merge( { counter: 1 } )
+      expect(server).to receive(:broadcast).with(channel, params)
+      expect(server).to receive(:broadcast).with(channel, second_params)
+      2.times { broadcaster.ask(player.uuid, "hoge") }
     end
   end
 


### PR DESCRIPTION
https://github.com/ishikota/PokerServer/issues/8 「round_managerで,askを送る度にcounterを増やして,それを各メッセージにつけるようにする」
の実装