### PR TITLE
Fix message around

### DIFF
--- a/app/channels/room_channel_delegate.rb
+++ b/app/channels/room_channel_delegate.rb
@@ -84,7 +84,7 @@ class RoomChannelDelegate
 
     def broadcast_dealer_message(room, messages)
       messages.each { |msg|
-        if msg["type"] == "notification"
+        if msg["type"] == "broadcast"
           @channel.broadcast(room_id=room.id, notification_message(msg["message"]))
         elsif msg["type"] == "ask"
           recipient = Player.find_by_uuid(msg["recipient"])

--- a/app/channels/room_channel_delegate.rb
+++ b/app/channels/room_channel_delegate.rb
@@ -86,6 +86,10 @@ class RoomChannelDelegate
       messages.each { |msg|
         if msg["type"] == "broadcast"
           @channel.broadcast(room_id=room.id, notification_message(msg["message"]))
+        elsif msg["type"] == "notification"
+          recipient = Player.find_by_uuid(msg["recipient"])
+          message = notification_message(msg["message"])
+          @channel.broadcast(room_id=room.id, player_id=recipient.id, message)
         elsif msg["type"] == "ask"
           recipient = Player.find_by_uuid(msg["recipient"])
           message = ask_message(msg["message"], room.game_state.ask_counter)

--- a/app/poker_engine/dealer.rb
+++ b/app/poker_engine/dealer.rb
@@ -71,7 +71,7 @@ class Dealer
   private
 
     def start_round
-      @round_manager.start_new_round(@table)
+      @round_manager.start_new_round(@round_count, @table)
     end
 
     def create_player(player_info)

--- a/app/poker_engine/dealer.rb
+++ b/app/poker_engine/dealer.rb
@@ -112,22 +112,22 @@ class Dealer
 
     def notify_game_start
       message = @message_builder.game_start_message(@config, @table.seats)
-      notification_message(message)
+      broadcast_message(message)
     end
 
     def notify_round_result(winners)
       message = @message_builder.round_result_message(@round_count, winners, @round_manager, @table)
-      notification_message(message)
+      broadcast_message(message)
     end
 
     def notify_game_result
       message = @message_builder.game_result_message(@table.seats)
-      notification_message(message)
+      broadcast_message(message)
     end
 
-    def notification_message(message)
+    def broadcast_message(message)
       {
-        "type" => "notification",
+        "type" => "broadcast",
         "message" => message
       }
     end

--- a/app/poker_engine/dealer.rb
+++ b/app/poker_engine/dealer.rb
@@ -116,7 +116,7 @@ class Dealer
     end
 
     def notify_round_result(winners)
-      message = @message_builder.round_result_message(winners, @round_manager, @table)
+      message = @message_builder.round_result_message(@round_count, winners, @round_manager, @table)
       notification_message(message)
     end
 

--- a/app/poker_engine/message_builder.rb
+++ b/app/poker_engine/message_builder.rb
@@ -22,11 +22,12 @@ class MessageBuilder
     }
   end
 
-  def round_start_message(player_pos, seats)
+  def round_start_message(round_count, player_pos, seats)
     player = seats.players[player_pos]
     hole_card = @formatter.format_player(player, holecard=true)["hole_card"]
     {
       "message_type" => Type::ROUND_START_MESSAGE,
+      "round_count" => round_count,
       "seats" => @formatter.format_seats(seats),
       "hole_card" => hole_card
     }

--- a/app/poker_engine/message_builder.rb
+++ b/app/poker_engine/message_builder.rb
@@ -72,12 +72,13 @@ class MessageBuilder
     }
   end
 
-  def round_result_message(winners, round_manager, table)
+  def round_result_message(round_count, winners, round_manager, table)
     winners = @formatter.format_winners(winners)
     round_state = @formatter.format_round_state(round_manager, table)
 
     {
       "message_type" => Type::ROUND_RESULT_MESSAGE,
+      "round_count" => round_count,
       "round_state" => round_state
      }.merge!(winners)
   end

--- a/app/poker_engine/round_manager.rb
+++ b/app/poker_engine/round_manager.rb
@@ -216,19 +216,19 @@ class RoundManager
       msgs = []
       table.seats.players.each_with_index { |player, idx|
         #TODO fix to notify to each person
-        msgs << notification_message(@message_builder.round_start_message(round_count, idx, table.seats))
+        msgs << broadcast_message(@message_builder.round_start_message(round_count, idx, table.seats))
       }
       msgs
     end
 
     def notify_street_start(table)
       message = @message_builder.street_start_message(self, table)
-      notification_message(message)
+      broadcast_message(message)
     end
 
     def notify_update(player_pos, action, amount, table)
       message = @message_builder.game_update_message(player_pos, action, amount, self, table)
-      notification_message(message)
+      broadcast_message(message)
     end
 
     def gen_ask_message(player_pos, round_manager, table)
@@ -246,9 +246,9 @@ class RoundManager
       }
     end
 
-    def notification_message(message)
+    def broadcast_message(message)
       {
-        "type" => "notification",
+        "type" => "broadcast",
         "message" => message
       }
     end

--- a/app/poker_engine/round_manager.rb
+++ b/app/poker_engine/round_manager.rb
@@ -70,9 +70,7 @@ class RoundManager
     @agree_num = 0
     @next_player = table.dealer_btn
     msgs = []
-    if table.seats.count_ask_wait_players != 1
-      msgs << notify_street_start(table)
-    end
+    msgs << notify_street_start(table) unless game_is_decided?(table)
 
     if street == PREFLOP
       msgs << preflop(table)
@@ -191,12 +189,16 @@ class RoundManager
     end
 
     def ask_if_needed(table)
-      if table.seats.count_ask_wait_players == 1
+      if game_is_decided?(table)
         @street += 1
         start_street(@street, table)
       else
         gen_ask_message(@next_player, self, table)
       end
+    end
+
+    def game_is_decided?(table)
+      table.seats.count_ask_wait_players == 1
     end
 
     def clear_action_histories(players)

--- a/app/poker_engine/round_manager.rb
+++ b/app/poker_engine/round_manager.rb
@@ -215,8 +215,8 @@ class RoundManager
     def notify_round_start(round_count, table)
       msgs = []
       table.seats.players.each_with_index { |player, idx|
-        #TODO fix to notify to each person
-        msgs << broadcast_message(@message_builder.round_start_message(round_count, idx, table.seats))
+        message = @message_builder.round_start_message(round_count, idx, table.seats)
+        msgs << notification_message(player, message)
       }
       msgs
     end
@@ -246,13 +246,20 @@ class RoundManager
       }
     end
 
+    def notification_message(recipient, message)
+      {
+        "type" => "notification",
+        "recipient" => recipient.uuid,
+        "message" => message
+      }
+    end
+
     def broadcast_message(message)
       {
         "type" => "broadcast",
         "message" => message
       }
     end
-
 
 end
 

--- a/app/poker_engine/round_manager.rb
+++ b/app/poker_engine/round_manager.rb
@@ -70,7 +70,9 @@ class RoundManager
     @agree_num = 0
     @next_player = table.dealer_btn
     msgs = []
-    msgs << notify_street_start(table)
+    if table.seats.count_ask_wait_players != 1
+      msgs << notify_street_start(table)
+    end
 
     if street == PREFLOP
       msgs << preflop(table)
@@ -81,7 +83,7 @@ class RoundManager
     elsif street == RIVER
       msgs << river(table)
     elsif street == SHOWDOWN
-      msgs << showdown(table)
+      showdown(table)
     end
 
     msgs.flatten

--- a/app/poker_engine/round_manager.rb
+++ b/app/poker_engine/round_manager.rb
@@ -31,7 +31,7 @@ class RoundManager
     @next_player = next_player
   end
 
-  def start_new_round(table)
+  def start_new_round(round_count, table)
     @next_player = table.dealer_btn
     @street = PREFLOP
 
@@ -39,7 +39,7 @@ class RoundManager
     correct_blind(small_blind=5, table)
     deal_holecard(table.deck, table.seats.players)
 
-    [].concat(notify_round_start(table))
+    [].concat(notify_round_start(round_count, table))
       .concat(start_street(@street, table))
   end
 
@@ -212,11 +212,11 @@ class RoundManager
       players.each { |player| player.clear_action_histories }
     end
 
-    def notify_round_start(table)
+    def notify_round_start(round_count, table)
       msgs = []
       table.seats.players.each_with_index { |player, idx|
         #TODO fix to notify to each person
-        msgs << notification_message(@message_builder.round_start_message(idx, table.seats))
+        msgs << notification_message(@message_builder.round_start_message(round_count, idx, table.seats))
       }
       msgs
     end

--- a/app/poker_engine/round_manager.rb
+++ b/app/poker_engine/round_manager.rb
@@ -70,7 +70,9 @@ class RoundManager
     @agree_num = 0
     @next_player = table.dealer_btn
     msgs = []
-    msgs << notify_street_start(table) unless game_is_decided?(table)
+    if table.seats.count_active_player != 1
+      msgs << notify_street_start(table)
+    end
 
     if street == PREFLOP
       msgs << preflop(table)
@@ -81,7 +83,7 @@ class RoundManager
     elsif street == RIVER
       msgs << river(table)
     elsif street == SHOWDOWN
-      showdown(table)
+      msgs << showdown(table)
     end
 
     msgs.flatten
@@ -189,16 +191,12 @@ class RoundManager
     end
 
     def ask_if_needed(table)
-      if game_is_decided?(table)
+      if table.seats.count_ask_wait_players == 1
         @street += 1
         start_street(@street, table)
       else
         gen_ask_message(@next_player, self, table)
       end
-    end
-
-    def game_is_decided?(table)
-      table.seats.count_ask_wait_players == 1
     end
 
     def clear_action_histories(players)

--- a/app/poker_engine/round_manager.rb
+++ b/app/poker_engine/round_manager.rb
@@ -70,9 +70,6 @@ class RoundManager
     @agree_num = 0
     @next_player = table.dealer_btn
     msgs = []
-    if table.seats.count_active_player != 1
-      msgs << notify_street_start(table)
-    end
 
     if street == PREFLOP
       msgs << preflop(table)
@@ -114,24 +111,31 @@ class RoundManager
     def preflop(table)
       2.times { shift_next_player(table.seats) }
       @agree_num = 1  # big blind already agreed
-      ask_if_needed(table)
+      send_street_message(table)
     end
 
     def flop(table)
       table.deck.draw_cards(3).each { |card|
         table.community_card.add(card)
       }
-      ask_if_needed(table)
+      send_street_message(table)
     end
 
     def turn(table)
       table.community_card.add(table.deck.draw_card)
-      ask_if_needed(table)
+      send_street_message(table)
     end
 
     def river(table)
       table.community_card.add(table.deck.draw_card)
-      ask_if_needed(table)
+      send_street_message(table)
+    end
+
+    def send_street_message(table)
+      msgs = []
+      msgs << notify_street_start_if_needed(table)  # maybe nil
+      msgs << ask_if_needed(table)
+      msgs.compact
     end
 
     def showdown(table)
@@ -198,6 +202,11 @@ class RoundManager
         gen_ask_message(@next_player, self, table)
       end
     end
+
+    def notify_street_start_if_needed(table)
+      notify_street_start(table) if table.seats.count_active_player != 1
+    end
+
 
     def clear_action_histories(players)
       players.each { |player| player.clear_action_histories }

--- a/spec/channels/room_channel_delegate_spec.rb
+++ b/spec/channels/room_channel_delegate_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe RoomChannelDelegate do
     context "when everyone is online and fiiled to capacity" do
       let(:dealer) { double("dealer") }
       let(:dealer_message) {
-        [] << notification_msg("notify_hoge") << ask_msg(player.uuid, "ask_fuga")
+        [] << broadcast_msg("notify_hoge") << ask_msg(player.uuid, "ask_fuga")
       }
 
       before {
@@ -179,7 +179,7 @@ RSpec.describe RoomChannelDelegate do
     let(:someone) { FactoryGirl.create(:player1) }
     let(:dealer) { double("dealer") }
     let(:dealer_message) {
-      [] << notification_msg("notify_hoge") << ask_msg(player.uuid, "ask_fuga")
+      [] << broadcast_msg("notify_hoge") << ask_msg(player.uuid, "ask_fuga")
     }
 
     before "create new game state" do

--- a/spec/features/dealer_spec.rb
+++ b/spec/features/dealer_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Dealer do
     let(:config) { Config.new(initial_stack=100, max_round=2) }
 
     before {
-      expect(message_builder).to receive(:round_start_message).with(0, anything).twice
+      expect(message_builder).to receive(:round_start_message).with(anything, 0, anything).twice
       dealer.start_game(create_players_info(2))
     }
 

--- a/spec/features/dealer_spec.rb
+++ b/spec/features/dealer_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Dealer do
 
       expect(table.seats.players[0].stack).to eq 0
       expect(table.seats.players[1].stack).to eq 200
-      expect(msgs).to include notification_msg(game_result_msg)
+      expect(msgs).to include broadcast_msg(game_result_msg)
     end
   end
 

--- a/spec/features/room_channel_delegate_spec.rb
+++ b/spec/features/room_channel_delegate_spec.rb
@@ -40,6 +40,40 @@ RSpec.describe Dealer do
     end
   end
 
+  describe "street start message" do
+    let(:action_data) { { "poker_action" => "call", "bet_amount" => 10 } }
+    let(:data) { setup_data(room, player1).merge!(action_data) }
+
+    let(:poker_msg) do
+      {
+        phase: "play_poker",
+        type: "notification",
+        message: flop_msg
+      }
+    end
+
+    let(:flop_msg) do
+      {
+        "message_type"=>"street_start_message",
+        "round_state"=> {
+          "street"=>"FLOP",
+          "community_card"=>[anything, anything, anything],
+          "dealer_btn" => anything,
+          "seats" => anything,
+          "pot" => anything,
+          "next_player"=> anything
+        },
+        "street"=>"FLOP"
+      }
+    end
+
+
+    it "should be sent after street setup is done" do
+      expect(channel).to receive(:broadcast).with(room.id, poker_msg)
+      delegate.declare_action(player1.uuid, data)
+    end
+  end
+
   private
 
     def setup_data(room, player)

--- a/spec/features/round_manager_spec.rb
+++ b/spec/features/round_manager_spec.rb
@@ -38,34 +38,34 @@ RSpec.describe RoundManager do
     }
 
     it "should notify starts of the round to all players" do
-      msgs = round_manager.start_new_round(table)
+      msgs = round_manager.start_new_round(1, table)
       expect(msgs).to include notification_msg("round starts")
       expect(msgs).to include notification_msg("street starts")
     end
 
     it "should collect blind" do
       expect {
-        round_manager.start_new_round(table)
+        round_manager.start_new_round(1, table)
       }.to change { player1.stack }.by(-5)
        .and change { player2.stack }.by(-10)
     end
 
     it "should deal hole card to players" do
       expect {
-        round_manager.start_new_round(table)
+        round_manager.start_new_round(1, table)
       }.to change { player1.hole_card.size }.by(2)
       .and change { player2.hole_card.size }.by(2)
     end
 
     it "should not ask blind player in preflop" do
-      msgs = round_manager.start_new_round(table)
+      msgs = round_manager.start_new_round(1, table)
       expect(msgs).to include ask_msg(player1.uuid, "ask")
     end
 
     context "when finished in PREFLOP" do
 
       before {
-        round_manager.start_new_round(table)
+        round_manager.start_new_round(1, table)
       }
 
       it "should reach showdown without asking and finish round" do
@@ -79,7 +79,7 @@ RSpec.describe RoundManager do
     describe "forward next street" do
 
       describe "PREFLOP to FLOP" do
-        before { round_manager.start_new_round(table) }
+        before { round_manager.start_new_round(1, table) }
 
         it "should forward to flop" do
           expect {
@@ -93,7 +93,7 @@ RSpec.describe RoundManager do
 
       describe "FLOP to TURN" do
         before {
-          round_manager.start_new_round(table)
+          round_manager.start_new_round(1, table)
           round_manager.apply_action(table, 'call', 10, action_checker)
           expect(round_manager.street).to eq RoundManager::FLOP
         }
@@ -112,7 +112,7 @@ RSpec.describe RoundManager do
 
       describe "TURN to RIVER" do
         before {
-          round_manager.start_new_round(table)
+          round_manager.start_new_round(1, table)
           round_manager.apply_action(table, 'call', 10, action_checker)
           round_manager.apply_action(table, 'raise', 10, action_checker)
           round_manager.apply_action(table, 'call', 10, action_checker)
@@ -133,7 +133,7 @@ RSpec.describe RoundManager do
 
       describe "RIVER to SHOWOFF" do
         before {
-          round_manager.start_new_round(table)
+          round_manager.start_new_round(1, table)
           round_manager.apply_action(table, 'call', 10, action_checker)
           round_manager.apply_action(table, 'call', 0, action_checker)
           round_manager.apply_action(table, 'call', 0, action_checker)
@@ -202,7 +202,7 @@ RSpec.describe RoundManager do
       describe "one player call and another is fold" do
 
         it "should forward to FLOP" do
-          round_manager.start_new_round(table)
+          round_manager.start_new_round(1, table)
           round_manager.apply_action(table, 'call', 10, action_checker)
 
           expect {

--- a/spec/features/round_manager_spec.rb
+++ b/spec/features/round_manager_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe RoundManager do
 
     it "should notify starts of the round to all players" do
       msgs = round_manager.start_new_round(1, table)
-      expect(msgs).to include broadcast_msg("round starts")
+      expect(msgs).to include notification_msg(player1.uuid, "round starts")
+      expect(msgs).to include notification_msg(player2.uuid, "round starts")
       expect(msgs).to include broadcast_msg("street starts")
     end
 

--- a/spec/features/round_manager_spec.rb
+++ b/spec/features/round_manager_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe RoundManager do
 
     it "should notify starts of the round to all players" do
       msgs = round_manager.start_new_round(1, table)
-      expect(msgs).to include notification_msg("round starts")
-      expect(msgs).to include notification_msg("street starts")
+      expect(msgs).to include broadcast_msg("round starts")
+      expect(msgs).to include broadcast_msg("street starts")
     end
 
     it "should collect blind" do
@@ -85,7 +85,7 @@ RSpec.describe RoundManager do
           expect {
             msgs = round_manager.apply_action(table, 'call', 10, action_checker)
             expect(msgs).to include ask_msg(player1.uuid, anything)
-            expect(msgs).to include notification_msg("street starts")
+            expect(msgs).to include broadcast_msg("street starts")
           }.to change { round_manager.street }.to(RoundManager::FLOP)
           .and change { table.community_card.cards.size }.from(0).to(3)
         end
@@ -104,7 +104,7 @@ RSpec.describe RoundManager do
           expect {
             msgs = round_manager.apply_action(table, 'call', 10, action_checker)
             expect(msgs).to include ask_msg(player1.uuid, anything)
-            expect(msgs).to include notification_msg("street starts")
+            expect(msgs).to include broadcast_msg("street starts")
           }.to change { round_manager.street }.to(RoundManager::TURN)
           .and change { table.community_card.cards.size }.from(3).to(4)
         end
@@ -125,7 +125,7 @@ RSpec.describe RoundManager do
           expect {
             msgs = round_manager.apply_action(table, 'call', 0, action_checker)
             expect(msgs).to include ask_msg(player1.uuid, anything)
-            expect(msgs).to include notification_msg("street starts")
+            expect(msgs).to include broadcast_msg("street starts")
           }.to change { round_manager.street }.to(RoundManager::RIVER)
           .and change { table.community_card.cards.size }.from(4).to(5)
         end

--- a/spec/poker_engine/data_formatter_spec.rb
+++ b/spec/poker_engine/data_formatter_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe DataFormatter do
 
     before {
       action_checler = ActionChecker.new
-      round_manager.start_new_round(table)
+      round_manager.start_new_round(1, table)
       round_manager.apply_action(table, 'call', 10, action_checler)  # forward to FLOP
     }
 

--- a/spec/poker_engine/dealer_spec.rb
+++ b/spec/poker_engine/dealer_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "Dealer" do
 
     it "should send game information to players" do
       msgs = dealer.start_game(player_info)
-      expect(msgs).to include notification_msg(game_start_msg)
+      expect(msgs).to include broadcast_msg(game_start_msg)
     end
 
     it "should start first round" do
@@ -110,7 +110,7 @@ RSpec.describe "Dealer" do
       allow(round_manager).to receive(:start_new_round).and_return([])
 
       msgs = dealer.finish_round_callback.call(winners, accounting_info)
-      expect(msgs).to include notification_msg(round_result_msg)
+      expect(msgs).to include broadcast_msg(round_result_msg)
     end
 
     describe "#teardown_round" do
@@ -171,7 +171,7 @@ RSpec.describe "Dealer" do
 
         it "should teardown the game and say goodbye to players" do
           msgs = dealer.finish_round_callback.call(winners, accounting_info)
-          expect(msgs).to include notification_msg(game_result_msg)
+          expect(msgs).to include broadcast_msg(game_result_msg)
         end
       end
 
@@ -187,7 +187,7 @@ RSpec.describe "Dealer" do
 
         it "should teardown the game" do
           msgs = dealer.finish_round_callback.call(winners, accounting_info)
-          expect(msgs).to include notification_msg(game_result_msg)
+          expect(msgs).to include broadcast_msg(game_result_msg)
         end
       end
 

--- a/spec/poker_engine/dealer_spec.rb
+++ b/spec/poker_engine/dealer_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Dealer" do
     end
 
     it "should start first round" do
-      expect(round_manager).to receive(:start_new_round).with(table).and_return([])
+      expect(round_manager).to receive(:start_new_round).with(1, table).and_return([])
       dealer.start_game(player_info)
     end
 

--- a/spec/poker_engine/message_builder_spec.rb
+++ b/spec/poker_engine/message_builder_spec.rb
@@ -90,8 +90,9 @@ RSpec.describe MessageBuilder do
     let(:winners) { [table.seats.players.first] }
 
     it "should create correct message" do
-      msg = message_builder.round_result_message(winners, round_manager, table)
+      msg = message_builder.round_result_message(7, winners, round_manager, table)
       expect(msg["message_type"]).to eq MessageBuilder::Type::ROUND_RESULT_MESSAGE
+      expect(msg["round_count"]).to eq 7
       expect(msg["winners"]).to eq formatter.format_winners(winners)["winners"]
       expect(msg["round_state"]).to eq formatter.format_round_state(round_manager, table)
     end

--- a/spec/poker_engine/message_builder_spec.rb
+++ b/spec/poker_engine/message_builder_spec.rb
@@ -26,8 +26,9 @@ RSpec.describe MessageBuilder do
     let(:seats) { setup_seats_with_players(2) }
 
     it "should create correct message for correct player" do
-      msg = message_builder.round_start_message(player_pos=1, seats)
+      msg = message_builder.round_start_message(7, player_pos=1, seats)
       expect(msg["message_type"]).to eq MessageBuilder::Type::ROUND_START_MESSAGE
+      expect(msg["round_count"]).to eq 7
       expect(msg["seats"]).to eq formatter.format_seats(seats)
       expect(msg["hole_card"]).to eq ["C8", "D3"]
     end
@@ -39,7 +40,7 @@ RSpec.describe MessageBuilder do
 
     before {
       action_checker = ActionChecker.new
-      round_manager.start_new_round(table)
+      round_manager.start_new_round(1, table)
       round_manager.apply_action(table, 'call', 10, action_checker)  # forward to FLOP
     }
 

--- a/spec/poker_engine/round_manager_apply_action_spec.rb
+++ b/spec/poker_engine/round_manager_apply_action_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe RoundManager do
       it "should notify update to all players" do
         setup_action_checker(player1, 0, 10)
         msgs = apply_action(round_manager, table, 'call', 10, action_checker)
-        expect(msgs).to include notification_msg("update")
+        expect(msgs).to include broadcast_msg("update")
       end
 
       context "when passed action is CALL" do
@@ -226,7 +226,7 @@ RSpec.describe RoundManager do
       it "should forward to next street" do
         setup_action_checker(player1, 0, 5)
         msgs = apply_action(round_manager, table, 'call', 5, action_checker)
-        expect(msgs).to include notification_msg("street_msg")
+        expect(msgs).to include broadcast_msg("street_msg")
       end
 
     end

--- a/spec/poker_engine/round_manager_basic_spec.rb
+++ b/spec/poker_engine/round_manager_basic_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe RoundManager do
       expect(message_builder).to receive(:street_start_message)
       expect(message_builder).to receive(:ask_message)
 
-      round_manager.start_new_round(table)
+      round_manager.start_new_round(1, table)
     end
 
     it "should collect blind" do
@@ -34,7 +34,7 @@ RSpec.describe RoundManager do
       expect(player1.pay_info).to receive(:update_by_pay).with(small_blind)
       expect(player2.pay_info).to receive(:update_by_pay).with(small_blind * 2)
 
-      round_manager.start_new_round(table)
+      round_manager.start_new_round(1, table)
     end
 
     it "should deal hole card to players" do
@@ -42,7 +42,7 @@ RSpec.describe RoundManager do
         expect(player).to receive(:add_holecard).with([anything, anything])
       }
 
-      round_manager.start_new_round(table)
+      round_manager.start_new_round(1, table)
     end
 
   end

--- a/spec/poker_engine/round_manager_spec_helper.rb
+++ b/spec/poker_engine/round_manager_spec_helper.rb
@@ -15,5 +15,13 @@ module RoundManagerSpecHelper
     }
   end
 
+  def notification_msg(recipient, message)
+    {
+      "type" => "notification",
+      "recipient" => recipient,
+      "message" => message
+    }
+  end
+
 end
 

--- a/spec/poker_engine/round_manager_spec_helper.rb
+++ b/spec/poker_engine/round_manager_spec_helper.rb
@@ -1,8 +1,8 @@
 module RoundManagerSpecHelper
 
-  def notification_msg(message)
+  def broadcast_msg(message)
     {
-      "type" => "notification",
+      "type" => "broadcast",
       "message" => message
     }
   end

--- a/spec/poker_engine/round_manager_street_spec.rb
+++ b/spec/poker_engine/round_manager_street_spec.rb
@@ -138,16 +138,39 @@ RSpec.describe RoundManager do
 
       before {
         allow(seats).to receive(:size).and_return(3)
-        allow(seats).to receive(:count_ask_wait_players).and_return 1
         allow(table.community_card).to receive(:add)
-        allow(finish_callback).to receive(:call)
+        allow(finish_callback).to receive(:call).and_return "finish_msg"
         allow(game_evaluator).to receive(:judge).and_return([[], []])
         allow(table).to receive(:reset)
       }
 
-      it "should skip start street notification" do
+      subject(:street_start_msgs) do
         msgs = round_manager.start_street(RoundManager::PREFLOP, table)
-        expect(msgs).to be_empty
+        msgs.select { |m| m["message"] == "street_start" }
+      end
+
+      context "by another player's allin" do
+
+        before {
+          allow(seats).to receive(:count_ask_wait_players).and_return 1
+          allow(seats).to receive(:count_active_player).and_return 2
+        }
+
+        it "should not skip start street notification" do
+          expect(street_start_msgs).not_to be_empty
+        end
+      end
+
+      context "by another player's fold" do
+
+        before {
+          allow(seats).to receive(:count_ask_wait_players).and_return 1
+          allow(seats).to receive(:count_active_player).and_return 1
+        }
+
+        it "should skip start street notification" do
+          expect(street_start_msgs).to be_empty
+        end
       end
     end
   end

--- a/spec/poker_engine/round_manager_street_spec.rb
+++ b/spec/poker_engine/round_manager_street_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe RoundManager do
   let(:round_manager) { RoundManager.new(game_evaluator, message_builder) }
 
   before {
-    allow(message_builder).to receive(:round_start_message)
-    allow(message_builder).to receive(:street_start_message)
-    allow(message_builder).to receive(:ask_message)
+    allow(message_builder).to receive(:round_start_message).and_return("round_start")
+    allow(message_builder).to receive(:street_start_message).and_return("street_start")
+    allow(message_builder).to receive(:ask_message).and_return("ask")
 
     round_manager.set_finish_callback(finish_callback)
   }
@@ -132,6 +132,25 @@ RSpec.describe RoundManager do
 
   end
 
+  describe "notification" do
+
+    describe "when only one player is active" do
+
+      before {
+        allow(seats).to receive(:size).and_return(3)
+        allow(seats).to receive(:count_ask_wait_players).and_return 1
+        allow(table.community_card).to receive(:add)
+        allow(finish_callback).to receive(:call)
+        allow(game_evaluator).to receive(:judge).and_return([[], []])
+        allow(table).to receive(:reset)
+      }
+
+      it "should skip start street notification" do
+        msgs = round_manager.start_street(RoundManager::PREFLOP, table)
+        expect(msgs).to be_empty
+      end
+    end
+  end
 
   private
 


### PR DESCRIPTION
### やったこと
- foldで残り1人になったとき，street startの情報いらないので，送信しないようにする．
  - d9def9f, 559d09e, a666a36
- street start messageを,streetのsetupをする前に送っていたので，後に送るように修正
  - 7a5225a
- round_start, round_result messageにround_countを追加
  - b667bb0, 8f73e48
- round_start message(HoleCardの情報が入ってる)を，全体に送らないように変更
  -  adefab7, d9e2ea2
